### PR TITLE
Add Camera class and FastAPI application for video streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI for GuardPiWatch
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/piwatcher/camera/README.md
+++ b/piwatcher/camera/README.md
@@ -1,0 +1,26 @@
+# Camera configuration
+
+This directory is used for the remote Raspberry Pis with the camera.
+
+- `camera.py`: This file defines a Camera class for managing a camera using OpenCV.
+  It includes methods to initialize the camera with specified width, height, and framerate, start the camera, capture frames, and release the camera resources.
+  The class ensures proper handling of the camera lifecycle, including cleanup on exit.
+- `app.py`: This file sets up a FastAPI application to stream video from a camera.
+  It initializes a Camera object, starts the camera, and defines an endpoint `/video/stream/` that streams the captured frames as MJPEG.
+  The gen_frames function captures frames from the camera and encodes them as JPEG images for streaming.
+
+## Usage
+
+First, install the necessary packages:
+
+```bash
+pip install -e ".[camera]"
+```
+
+Then, navigate to the `piwatcher/camera` directory and run:
+
+```bash
+ uvicorn app:app --host 0.0.0.0 --port 8000
+ ```
+
+Open your web browser and navigate to `http://<your-ip-address>:8000/video/stream/` to view the video stream.

--- a/piwatcher/camera/app.py
+++ b/piwatcher/camera/app.py
@@ -1,0 +1,33 @@
+import cv2
+from camera import Camera
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+app = FastAPI(title="PiWatcher Camera", version="0.1.0")
+
+
+camera = Camera(width=640, height=480, framerate=6)
+camera.start_camera()
+
+
+def gen_frames():
+    while True:
+        frame = camera.get_frame()
+        if frame is not None:
+            ret, buffer = cv2.imencode(".jpg", frame)
+            if ret:
+                # Convert the buffer to bytes and yield it for MJPEG streaming
+                frame_bytes = buffer.tobytes()
+                yield (
+                    b"--frame\r\n"
+                    b"Content-Type: image/jpeg\r\n\r\n"
+                    + frame_bytes
+                    + b"\r\n\r\n"
+                )
+
+
+@app.get("/video/stream/")
+def video_stream():
+    return StreamingResponse(
+        gen_frames(), media_type="multipart/x-mixed-replace; boundary=frame"
+    )

--- a/piwatcher/camera/camera.py
+++ b/piwatcher/camera/camera.py
@@ -1,0 +1,64 @@
+import cv2
+
+
+class Camera:
+    def __init__(
+        self, width: int = 640, height: int = 480, framerate: int = 6
+    ) -> None:
+        """
+        Initializes the Camera object with the specified width,
+            height, and framerate.
+
+        Args:
+            width (int): The width of the camera frame. Defaults to 640.
+            height (int): The height of the camera frame. Defaults to 480.
+            framerate (int): The framerate of the camera. Defaults to 6.
+        """
+        self.cap = None
+        self.width = width
+        self.height = height
+        self.framerate = framerate
+
+    def start_camera(self):
+        """
+        Start the camera.
+
+        Returns:
+            None
+        """
+        self.cap = cv2.VideoCapture(0)
+        if not self.cap.isOpened():
+            raise RuntimeError("Could not open camera")
+        self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.width)
+        self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.height)
+        self.cap.set(cv2.CAP_PROP_FPS, self.framerate)
+        return None
+
+    def get_frame(self) -> cv2.Mat:
+        """
+        Get a frame from the camera.
+
+        Returns:
+            cv2.Mat: The captured frame, or None if the frame
+                could not be captured.
+        """
+        if self.cap:
+            ret, frame = self.cap.read()
+            if ret:
+                return frame
+        return None
+
+    def stop_camera(self) -> None:
+        """
+        Release the camera.
+
+        Returns:
+            None
+        """
+        if self.cap:
+            self.cap.release()
+            self.cap = None
+        return None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_camera()


### PR DESCRIPTION
# Add Camera class and FastAPI application for video streaming

## Description

- Added `camera.py` defining a `Camera` class for managing a camera using OpenCV.
  - Includes methods to initialize, start, capture frames, and release the camera.
- Added `app.py` to set up a FastAPI application for streaming video from the camera.
  - Initializes a `Camera` object, starts the camera, and defines an endpoint `/video/stream/` for MJPEG streaming.
- Updated README.md with instructions for installing dependencies and running the application.
- Modified GitHub Actions workflow to trigger on pull requests only.

Closes #3 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

